### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/ioUtil/keywords.txt
+++ b/ioUtil/keywords.txt
@@ -1,12 +1,12 @@
 # classes and datatypes, KEYWORD1
 # methods and functions, KEYWORD2
 # constants (defines) LITERAL1
-SerialLineBuffer KEYWORD1
-isComplete       KEYWORD2
-clear            KEYWORD2
-length           KEYWORD2
-maxLength        KEYWORD2
-get              KEYWORD2
+SerialLineBuffer	KEYWORD1
+isComplete	KEYWORD2
+clear	KEYWORD2
+length	KEYWORD2
+maxLength	KEYWORD2
+get	KEYWORD2
 
 # this is a data member, exposed.  See if there is a KEYWORD3?
-buf KEYWORD3
+buf	KEYWORD3


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords